### PR TITLE
🎉 Feature: add cli support 

### DIFF
--- a/CLI_USAGE.md
+++ b/CLI_USAGE.md
@@ -1,0 +1,115 @@
+# 📦 Package Classifier CLI Usage
+
+## 🚀 Running from Gradle
+
+### Show Help
+```bash
+./gradlew runCli
+```
+
+### sort a Package
+```bash
+./gradlew sort -Pargs="width,height,length,mass"
+```
+
+**Examples:**
+```bash
+# Standard package
+./gradlew sort -Pargs="50,30,20,5000"
+# Output: STANDARD
+
+# Bulky package (dimension >= 150cm)
+./gradlew sort -Pargs="150,30,20,5000"
+# Output: SPECIAL
+
+# Heavy package (weight >= 20kg)
+./gradlew sort -Pargs="50,30,20,25000"
+# Output: SPECIAL
+
+# Rejected package (both bulky and heavy)
+./gradlew sort -Pargs="150,30,20,25000"
+# Output: REJECTED
+
+# Bulky by volume (100^3 = 1,000,000 cm³)
+./gradlew sort -Pargs="100,100,100,15000"
+# Output: SPECIAL
+```
+
+## 📦 Running Standalone JAR
+
+### Build the JAR
+```bash
+./gradlew buildCli
+```
+
+### Run the JAR
+```bash
+# Show help
+java -jar build/libs/packages-factory-1.0-SNAPSHOT.jar --help
+
+# sort packages
+java -jar build/libs/packages-factory-1.0-SNAPSHOT.jar "50,30,20,5000"
+java -jar build/libs/packages-factory-1.0-SNAPSHOT.jar "150,30,20,25000"
+```
+
+## 📋 Input Format
+
+**Required format:** `"width,height,length,mass"`
+
+- **width** - Package width in centimeters (positive integer)
+- **height** - Package height in centimeters (positive integer) 
+- **length** - Package length in centimeters (positive integer)
+- **mass** - Package mass in grams (positive number, can be decimal)
+
+## 📤 Output
+
+The CLI returns one of three stack types:
+
+- **STANDARD** - Normal processing (not bulky, not heavy)
+- **SPECIAL** - Special handling (bulky OR heavy, but not both)
+- **REJECTED** - Cannot process (both bulky AND heavy)
+
+## 🏷️ Classification Rules
+
+### BULKY Package
+- Any dimension ≥ 150 cm **OR**
+- Total volume ≥ 1,000,000 cm³
+
+### HEAVY Package  
+- Mass ≥ 20,000 grams (20 kg)
+
+### Stack Assignment
+- **BULKY AND HEAVY** → REJECTED
+- **BULKY OR HEAVY** (not both) → SPECIAL
+- **Neither** → STANDARD
+
+## ⚠️ Error Handling
+
+```bash
+# Wrong number of parameters
+./gradlew sort -Pargs="50,30"
+# Error: Input must have exactly 4 comma-separated values
+
+# Invalid numbers
+./gradlew sort -Pargs="abc,30,20,5000"
+# Error: All values must be valid numbers
+
+# Negative values
+./gradlew sort -Pargs="-50,30,20,5000"
+# Error: All dimensions and mass must be positive values
+```
+
+## 🎯 Testing with Unit Test Cases
+
+The CLI uses the same format as the unit tests, so you can directly test any test case:
+
+```bash
+# From PackageFactoryTest cases
+./gradlew sort -Pargs="50,50,50,10000"     # STANDARD
+./gradlew sort -Pargs="100,50,30,15000"    # STANDARD  
+./gradlew sort -Pargs="99,99,99,19999"     # STANDARD
+./gradlew sort -Pargs="150,10,10,5000"     # SPECIAL (bulky)
+./gradlew sort -Pargs="10,10,10,25000"     # SPECIAL (heavy)
+./gradlew sort -Pargs="150,150,150,25000"  # REJECTED (both)
+```
+

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ An intelligent classification system that analyzes **box measurements** (length,
 - [Code Coverage](#-code-coverage)
 - [System Usage](#-system-usage)
 - [Algorithm Details](#-algorithm-details)
+- [Client Interfaces](#-client-interfaces)
 - [Development](#-development)
 
 ## 🎯 System Overview
@@ -474,6 +475,21 @@ Boxes with volume ≥ 1,000,000 cm³ are classified as BULKY even if no single d
 4. Apply classification rules
 5. Determine stack assignment
 6. Return result
+
+## 🖥️ Client Interfaces
+
+The system supports multiple client interfaces for integration and usage:
+
+* [x] ✅ CLI** - Command-line interface for direct system interaction
+* [ ] 📋 API** - REST API for programmatic integration `(TODO)`
+
+### CLI Interface
+
+The CLI interface provides direct access to the box classification system through command-line operations. See [CLI_USAGE.md](CLI_USAGE.md) for detailed usage instructions.
+
+### API Interface
+
+REST API implementation is planned for future releases to enable programmatic integration with external systems.
 
 ## 🛠️ Development
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,9 @@
 plugins {
     id("java")
+    id("application")
     id("jacoco")
+    id("org.springframework.boot") version "3.2.0"
+    id("io.spring.dependency-management") version "1.1.4"
 }
 
 group = "org.example"
@@ -22,7 +25,9 @@ tasks.withType<JavaExec> {
 }
 
 dependencies {
+    implementation("org.springframework.boot:spring-boot-starter")
     implementation("com.google.guava:guava:33.4.8-jre")
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation(platform("org.junit:junit-bom:5.10.0"))
     testImplementation("org.junit.jupiter:junit-jupiter")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -226,3 +226,47 @@ tasks.register("testWithCoverage") {
     group = "verification"
     description = "Runs tests and generates code coverage reports"
 }
+
+// Task to run the CLI application with help
+tasks.register<JavaExec>("runCli") {
+    dependsOn("classes")
+    group = "application"
+    description = "Runs the package classifier CLI application with help"
+    classpath = sourceSets["main"].runtimeClasspath
+    mainClass.set("ai.thoughtful.platform.factory.PackageSorterApplication")
+    args = listOf("--help")
+}
+
+// Task to run the CLI with custom arguments
+tasks.register<JavaExec>("sort") {
+    dependsOn("classes")
+    group = "application"
+    description = "Classifies a package. Usage: gradle sort -Pargs='width,height,length,mass'"
+    classpath = sourceSets["main"].runtimeClasspath
+    mainClass.set("ai.thoughtful.platform.factory.PackageSorterApplication")
+    
+    if (project.hasProperty("args")) {
+        args = listOf(project.property("args").toString())
+    } else {
+        args = listOf("--help")
+    }
+}
+
+// Configure application main class
+application {
+    mainClass.set("ai.thoughtful.platform.factory.PackageSorterApplication")
+}
+
+// Task to build executable JAR
+tasks.register("buildCli") {
+    dependsOn("bootJar")
+    group = "build"
+    description = "Builds the executable CLI JAR file"
+    doLast {
+        println("\n✅ CLI JAR built successfully!")
+        println("📦 Location: ${layout.buildDirectory.get()}/libs/${project.name}-${project.version}.jar")
+        println("\n🚀 Usage:")
+        println("  java -jar build/libs/${project.name}-${project.version}.jar \"50,30,20,5000\"")
+        println("  java -jar build/libs/${project.name}-${project.version}.jar --help")
+    }
+}

--- a/src/main/java/ai/thoughtful/platform/factory/PackageSorterApplication.java
+++ b/src/main/java/ai/thoughtful/platform/factory/PackageSorterApplication.java
@@ -1,0 +1,16 @@
+package ai.thoughtful.platform.factory;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * Spring Boot application for package classification command-line interface.
+ */
+@SpringBootApplication
+public class PackageSorterApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(PackageSorterApplication.class, args);
+    }
+}
+

--- a/src/main/java/ai/thoughtful/platform/factory/cli/PackageClassifierRunner.java
+++ b/src/main/java/ai/thoughtful/platform/factory/cli/PackageClassifierRunner.java
@@ -1,0 +1,126 @@
+package ai.thoughtful.platform.factory.cli;
+
+import ai.thoughtful.platform.factory.StackType;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+/**
+ * Command-line runner that processes package measurements and returns stack type.
+ * 
+ * Expected input format: "width,height,length,mass"
+ * Example: "50,30,20,5000" -> "STANDARD"
+ */
+@Component
+public class PackageClassifierRunner implements CommandLineRunner {
+
+    @Override
+    public void run(String... args) throws Exception {
+        if (args.length == 0) {
+            printUsage();
+            return;
+        }
+
+        String input = args[0];
+        
+        if ("--help".equals(input) || "-h".equals(input)) {
+            printHelp();
+            return;
+        }
+
+        try {
+            String stackType = classifyPackage(input);
+            System.out.println(stackType);
+        } catch (IllegalArgumentException e) {
+            System.err.println("Error: " + e.getMessage());
+            printUsage();
+            System.exit(1);
+        } catch (Exception e) {
+            System.err.println("Unexpected error: " + e.getMessage());
+            System.exit(1);
+        }
+    }
+
+    /**
+     * Classifies a package based on the input string format.
+     * 
+     * @param input comma-separated values: "width,height,length,mass"
+     * @return stack type as string (STANDARD, SPECIAL, or REJECTED)
+     * @throws IllegalArgumentException if input format is invalid
+     */
+    private String classifyPackage(String input) {
+        if (input == null || input.trim().isEmpty()) {
+            throw new IllegalArgumentException("Input cannot be empty");
+        }
+
+        String[] parts = input.split(",");
+        if (parts.length != 4) {
+            throw new IllegalArgumentException(
+                "Input must have exactly 4 comma-separated values: width,height,length,mass");
+        }
+
+        try {
+            int width = Integer.parseInt(parts[0].trim());
+            int height = Integer.parseInt(parts[1].trim());
+            int length = Integer.parseInt(parts[2].trim());
+            double mass = Double.parseDouble(parts[3].trim());
+
+            // Validate inputs
+            if (width <= 0 || height <= 0 || length <= 0 || mass <= 0) {
+                throw new IllegalArgumentException(
+                    "All dimensions and mass must be positive values");
+            }
+
+            if (!Double.isFinite(mass)) {
+                throw new IllegalArgumentException(
+                    "Mass must be a finite number");
+            }
+
+            // Use StackType.sort method to get classification
+            return StackType.sort(width, height, length, mass);
+
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException(
+                "All values must be valid numbers. Width, height, and length must be integers, mass can be decimal.");
+        }
+    }
+
+    private void printUsage() {
+        System.out.println("Usage: java -jar package-classifier.jar \"width,height,length,mass\"");
+        System.out.println("Example: java -jar package-classifier.jar \"50,30,20,5000\"");
+        System.out.println("Use --help for more information.");
+    }
+
+    private void printHelp() {
+        System.out.println("📦 Package Classification System");
+        System.out.println("================================");
+        System.out.println();
+        System.out.println("This tool classifies packages and determines their stack assignment based on");
+        System.out.println("dimensions and weight.");
+        System.out.println();
+        System.out.println("USAGE:");
+        System.out.println("  java -jar package-classifier.jar \"width,height,length,mass\"");
+        System.out.println();
+        System.out.println("PARAMETERS:");
+        System.out.println("  width  - Package width in centimeters (positive integer)");
+        System.out.println("  height - Package height in centimeters (positive integer)");
+        System.out.println("  length - Package length in centimeters (positive integer)");
+        System.out.println("  mass   - Package mass in grams (positive number)");
+        System.out.println();
+        System.out.println("OUTPUT:");
+        System.out.println("  STANDARD - Normal processing (not bulky, not heavy)");
+        System.out.println("  SPECIAL  - Special handling (bulky OR heavy, but not both)");
+        System.out.println("  REJECTED - Cannot process (both bulky AND heavy)");
+        System.out.println();
+        System.out.println("CLASSIFICATION RULES:");
+        System.out.println("  • BULKY: Any dimension ≥ 150cm OR volume ≥ 1,000,000 cm³");
+        System.out.println("  • HEAVY: Mass ≥ 20,000 grams (20 kg)");
+        System.out.println();
+        System.out.println("EXAMPLES:");
+        System.out.println("  \"50,30,20,5000\"     -> STANDARD (normal size and weight)");
+        System.out.println("  \"150,30,20,5000\"    -> SPECIAL  (bulky by dimension)");
+        System.out.println("  \"50,30,20,25000\"    -> SPECIAL  (heavy package)");
+        System.out.println("  \"150,30,20,25000\"   -> REJECTED (both bulky and heavy)");
+        System.out.println("  \"100,100,100,15000\" -> SPECIAL  (bulky by volume: 1M cm³)");
+    }
+}
+


### PR DESCRIPTION
# 🎉 New Feature

* Add CLI support from Gradle or the Built binary
  * Executable binary is a Java Jar

# ⌨️ CLI Support

* Just executing from the CLI

```console
./gradlew sort -Pargs="10,30,20,5000"
WARNING: A restricted method in java.lang.System has been called
WARNING: java.lang.System::load has been called by net.rubygrapefruit.platform.internal.NativeLibraryLoader in an unnamed module (file:/Users/marcellodesales/.gradle/wrapper/dists/gradle-8.10-bin/deqhafrv1ntovfmgh0nh3npr9/gradle-8.10/lib/native-platform-0.22-milestone-26.jar)
WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for callers in this module
WARNING: Restricted methods will be blocked in a future release unless native access is enabled


> Task :sort

  .   ____          _            __ _ _
 /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
 \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
  '  |____| .__|_| |_|_| |_\__, | / / / /
 =========|_|==============|___/=/_/_/_/
 :: Spring Boot ::                (v3.2.0)

2025-06-05T07:44:58.484-07:00  INFO 34706 --- [           main] a.t.p.factory.PackageSorterApplication   : Starting PackageSorterApplication using Java 24.0.1 with PID 34706 (/Users/marcellodesales/dev/github.com/marcellodesales/package-problem-java/untitled/build/classes/java/main started by marcellodesales in /Users/marcellodesales/dev/github.com/marcellodesales/package-problem-java/untitled)
2025-06-05T07:44:58.485-07:00  INFO 34706 --- [           main] a.t.p.factory.PackageSorterApplication   : No active profile set, falling back to 1 default profile: "default"
2025-06-05T07:44:58.657-07:00  INFO 34706 --- [           main] a.t.p.factory.PackageSorterApplication   : Started PackageSorterApplication in 0.274 seconds (process running for 0.377)
STANDARD

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.10/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD SUCCESSFUL in 3s
2 actionable tasks: 1 executed, 1 up-to-date
./gradlew sort -Pargs="10,30,20,33000"
WARNING: A restricted method in java.lang.System has been called
WARNING: java.lang.System::load has been called by net.rubygrapefruit.platform.internal.NativeLibraryLoader in an unnamed module (file:/Users/marcellodesales/.gradle/wrapper/dists/gradle-8.10-bin/deqhafrv1ntovfmgh0nh3npr9/gradle-8.10/lib/native-platform-0.22-milestone-26.jar)
WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for callers in this module
WARNING: Restricted methods will be blocked in a future release unless native access is enabled


> Task :sort

  .   ____          _            __ _ _
 /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
 \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
  '  |____| .__|_| |_|_| |_\__, | / / / /
 =========|_|==============|___/=/_/_/_/
 :: Spring Boot ::                (v3.2.0)

2025-06-05T07:45:07.326-07:00  INFO 34776 --- [           main] a.t.p.factory.PackageSorterApplication   : Starting PackageSorterApplication using Java 24.0.1 with PID 34776 (/Users/marcellodesales/dev/github.com/marcellodesales/package-problem-java/untitled/build/classes/java/main started by marcellodesales in /Users/marcellodesales/dev/github.com/marcellodesales/package-problem-java/untitled)
2025-06-05T07:45:07.327-07:00  INFO 34776 --- [           main] a.t.p.factory.PackageSorterApplication   : No active profile set, falling back to 1 default profile: "default"
2025-06-05T07:45:07.502-07:00  INFO 34776 --- [           main] a.t.p.factory.PackageSorterApplication   : Started PackageSorterApplication in 0.279 seconds (process running for 0.386)
SPECIAL

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.10/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD SUCCESSFUL in 3s
2 actionable tasks: 1 executed, 1 up-to-date
./gradlew sort -Pargs="1034,30,20,33000"
WARNING: A restricted method in java.lang.System has been called
WARNING: java.lang.System::load has been called by net.rubygrapefruit.platform.internal.NativeLibraryLoader in an unnamed module (file:/Users/marcellodesales/.gradle/wrapper/dists/gradle-8.10-bin/deqhafrv1ntovfmgh0nh3npr9/gradle-8.10/lib/native-platform-0.22-milestone-26.jar)
WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for callers in this module
WARNING: Restricted methods will be blocked in a future release unless native access is enabled


> Task :sort

  .   ____          _            __ _ _
 /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
 \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
  '  |____| .__|_| |_|_| |_\__, | / / / /
 =========|_|==============|___/=/_/_/_/
 :: Spring Boot ::                (v3.2.0)

2025-06-05T07:45:20.572-07:00  INFO 34849 --- [           main] a.t.p.factory.PackageSorterApplication   : Starting PackageSorterApplication using Java 24.0.1 with PID 34849 (/Users/marcellodesales/dev/github.com/marcellodesales/package-problem-java/untitled/build/classes/java/main started by marcellodesales in /Users/marcellodesales/dev/github.com/marcellodesales/package-problem-java/untitled)
2025-06-05T07:45:20.574-07:00  INFO 34849 --- [           main] a.t.p.factory.PackageSorterApplication   : No active profile set, falling back to 1 default profile: "default"
2025-06-05T07:45:20.757-07:00  INFO 34849 --- [           main] a.t.p.factory.PackageSorterApplication   : Started PackageSorterApplication in 0.287 seconds (process running for 0.391)
REJECTED

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.10/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD SUCCESSFUL in 3s
2 actionable tasks: 1 executed, 1 up-to-date
```